### PR TITLE
Word lemmas depend on real number axioms

### DIFF
--- a/Word.v
+++ b/Word.v
@@ -9,6 +9,18 @@ Require Import bbv.Nomega.
 Require Export bbv.NatLib.
 Require Export bbv.DepEq bbv.DepEqNat.
 
+(** [intuition] means [intuition auto with *]. This makes [intuition] use all hint databases
+    ever declared. In particular, it might start using the HintDb 'real' (imported by Psatz),
+    which contains axioms about the real numbers, to solve goals on nat or Z, so lemmas
+    which should be axiom free will depend on axioms about R for.
+    It's also very fragile and slow.
+    We change this bad default as follows: *)
+Tactic Notation "intuition" tactic3(tactic) := intuition tactic.
+Tactic Notation "intuition" := intuition auto with zarith.
+
+(** [firstorder] means [firstorder auto with *], same problem as with [intuition]. *)
+Global Set Firstorder Solver auto with zarith.
+
 Set Implicit Arguments.
 
 (*! Definitions *)


### PR DESCRIPTION
On current master (38fe6a40ea26ce738637e340d7f8e9f0eb85fbc3) of bbv, if I do 

```
Print Assumptions roundTrip_0.
```

I get output like this:

```
Raxioms.total_order_T : forall r1 r2 : Rdefinitions.R,
                        {Rdefinitions.Rlt r1 r2} + {r1 = r2} + {Rdefinitions.Rgt r1 r2}
Raxioms.Rplus_opp_r : forall r : Rdefinitions.R,
                      Rdefinitions.Rplus r (Rdefinitions.Ropp r) = Rdefinitions.IZR 0
Raxioms.Rplus_lt_compat_l : forall r r1 r2 : Rdefinitions.R,
                            Rdefinitions.Rlt r1 r2 ->
                            Rdefinitions.Rlt (Rdefinitions.Rplus r r1) (Rdefinitions.Rplus r r2)
Raxioms.Rplus_comm : forall r1 r2 : Rdefinitions.R,
                     Rdefinitions.Rplus r1 r2 = Rdefinitions.Rplus r2 r1
Raxioms.Rplus_assoc : forall r1 r2 r3 : Rdefinitions.R,
                      Rdefinitions.Rplus (Rdefinitions.Rplus r1 r2) r3 =
... truncated because so long ...
```

This is unacceptable -- I want my theorems based on bbv to be axiom free.

Some time ago, the output was

```
Closed under the global context
```

as expected.

Using `git bisect`, I found that the problem was introduced in 02043b9b599165c2d99817257a6b1dc81fcf3af5.

This commit imports `Psatz`, which makes available the hint database called `real`, which contains axioms about the real numbers. (This can be confirmed by running `Print Hint *.` before importing `Psatz` and after importing it and compare the outputs by searching for 'axi').

Moreover, note that the `intuition` tactic is an alias for `intuition auto with *`.

Now, the proof of `roundTrip_0` uses `intuition`, and apparently its `auto with *` uses real number arithmetic to solve some subgoals.

I tried two ways to solve this:

### Approach 1: Strict hint behavior

Add the following after all imports in `Word.v`:

```
(* Emulates an import-scoped hint mechanism (what you'd expect), i.e. hints and hint
   databases are only available if you import their module, but not if they are declared
   in a transitive dependency of some imported module. *)
Set Loose Hint Behavior "Strict".

(* these modules contain Rewrite Hints which are actually useful and needed: *)
Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
Import Coq.ZArith.BinInt.Z.
Import Coq.NArith.BinNat.N.
Import Coq.Arith.PeanoNat.Nat.
Import Coq.Logic.Eqdep.EqdepTheory.
```

However, this requires me to import modules such as `Coq.Arith.PeanoNat.Nat` to make their hints available, but this redefines things such as `eq_refl`: It now has the type `Reflexive Logic.eq`, which is not compatible with normal `eq_refl`.

I did not succeed in making this approach work.


### Approach 2: Redefine intuition

Redefine `intuition` (and `firstorder` too) to do `auto with zarith` instead of `auto with *` (done in this PR).

This works in the sense that `Print Assumptions roundTrip_0.` now prints `Closed under the global context`, but it does not really solve the problem that a lot of potentially unwanted hints are still lingering around and might be picked up by other tactics, or might slow down proof search.



### Questions:

*   Will this PR break any projects using `bbv`?
*   Can we make approach 1 (which seems superior to me) work?


