### PR TITLE
add lemmas about ZToWord and about natToWord and mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# we don't use travis, but the mit-plv organization enabled it for all repos by default,
+# so we blacklist all branches:
+branches:
+  except:
+    - /.*/

--- a/NatLib.v
+++ b/NatLib.v
@@ -220,6 +220,13 @@ Proof.
   intros. pose proof (zero_lt_pow2 sz). omega.
 Qed.
 
+Lemma pow2_ne_zero: forall n, pow2 n <> 0.
+Proof.
+  intros.
+  pose proof (zero_lt_pow2 n).
+  omega.
+Qed.
+
 Lemma mul2_add : forall n, n * 2 = n + n.
 Proof.
   induction n; firstorder.
@@ -431,6 +438,15 @@ Proof.
   destruct (Npow2 n); auto.
   rewrite <-Pos.add_diag.
   reflexivity.
+Qed.
+
+Lemma Npow2_pos: forall a,
+    (0 < Npow2 a)%N.
+Proof.
+  intros.
+  destruct (Npow2 a) eqn: E.
+  - exfalso. apply (Npow2_not_zero a). assumption.
+  - constructor.
 Qed.
 
 Lemma minus_minus: forall a b c,


### PR DESCRIPTION
Only backwards-compatible additions, so I could also have just pushed this, but I made a PR because I'm adding `Require Import Coq.micromega.Lia.` -- is that fine?

It adds hints about rational numbers, but nothing about real numbers, so `auto with *` might become a bit slower, and I'm not doing anything about that. Does anyone have experience with `Set Loose Hint Behavior "Strict".`, which might help here, but I didn't get to work as explained in https://github.com/mit-plv/bbv/pull/6?