### PR TITLE
Move notations to their own modules

### DIFF
--- a/theories/BinNotationZ.v
+++ b/theories/BinNotationZ.v
@@ -1,7 +1,8 @@
 Require Export bbv.BinNotation.
+Require Export bbv.ReservedNotations.
 Require Import Coq.ZArith.BinInt.
 
-Notation "'Ob' a" := (Z.of_N (bin a)) (at level 50).
+Notation "'Ob' a" := (Z.of_N (bin a)).
 
 Goal Ob"01000001" = 65%Z.
 Proof. reflexivity. Qed.

--- a/theories/HexNotationZ.v
+++ b/theories/HexNotationZ.v
@@ -1,7 +1,8 @@
 Require Export bbv.HexNotation.
+Require Export bbv.ReservedNotations.
 Require Import Coq.ZArith.BinInt.
 
-Notation "'Ox' a" := (Z.of_N (hex a)) (at level 50).
+Notation "'Ox' a" := (Z.of_N (hex a)).
 
 Goal Ox"41" = 65%Z.
 Proof. reflexivity. Qed.

--- a/theories/ReservedNotations.v
+++ b/theories/ReservedNotations.v
@@ -1,0 +1,21 @@
+Reserved Notation "'Ob' a" (at level 50).
+Reserved Notation "'Ox' a" (at level 50).
+Reserved Notation "sz ''h' a" (at level 50).
+Reserved Notation "'Ox' a" (at level 50).
+Reserved Notation "l ^+ r" (at level 50, left associativity).
+Reserved Notation "l ^* r" (at level 40, left associativity).
+Reserved Notation "l ^- r" (at level 50, left associativity).
+Reserved Notation "l ^/ r" (at level 50, left associativity).
+Reserved Notation "l ^% r" (at level 50, left associativity).
+Reserved Notation "l ^| r" (at level 50, left associativity).
+Reserved Notation "l ^& r" (at level 40, left associativity).
+Reserved Notation "w1 '>s' w2" (at level 70, w2 at next level).
+Reserved Notation "w1 '>s=' w2" (at level 70, w2 at next level).
+Reserved Notation "w1 '<s' w2" (at level 70, w2 at next level).
+Reserved Notation "w1 '<s=' w2" (at level 70, w2 at next level).
+Reserved Notation "$ n" (at level 9, n at level 9, format "$ n").
+Reserved Notation "# n" (at level 0).
+Reserved Notation "l ^<< r" (at level 35).
+Reserved Notation "l ^>> r" (at level 35).
+Reserved Notation "w ~ 1" (at level 7, left associativity, format "w '~' '1'").
+Reserved Notation "w ~ 0" (at level 7, left associativity, format "w '~' '0'").

--- a/theories/Word.v
+++ b/theories/Word.v
@@ -8,6 +8,7 @@ Require Import Coq.setoid_ring.Ring_polynom.
 Require Import bbv.Nomega.
 Require Export bbv.ZLib bbv.NatLib bbv.NLib.
 Require Export bbv.DepEq bbv.DepEqNat.
+Require Import bbv.ReservedNotations.
 
 Require Import Coq.micromega.Lia.
 (* for nia (integer arithmetic with multiplications that omega cannot solve *)
@@ -242,17 +243,17 @@ Definition wmultN' sz (x y : word sz) : word sz :=
 
 Definition wminusN sz (x y : word sz) : word sz := wplusN x (wnegN y).
 
-Notation "w ~ 1" := (WS true w)
- (at level 7, left associativity, format "w '~' '1'") : word_scope.
-Notation "w ~ 0" := (WS false w)
- (at level 7, left associativity, format "w '~' '0'") : word_scope.
+Module Import ArithmeticNotations.
+  Notation "w ~ 1" := (WS true w) : word_scope.
+  Notation "w ~ 0" := (WS false w) : word_scope.
 
-Notation "^~" := wneg.
-Notation "l ^+ r" := (@wplus _ l%word r%word) (at level 50, left associativity).
-Notation "l ^* r" := (@wmult _ l%word r%word) (at level 40, left associativity).
-Notation "l ^- r" := (@wminus _ l%word r%word) (at level 50, left associativity).
-Notation "l ^/ r" := (@wdiv _ l%word r%word) (at level 50, left associativity).
-Notation "l ^% r" := (@wmod _ l%word r%word) (at level 50, left associativity).
+  Notation "^~" := wneg : word_scope.
+  Notation "l ^+ r" := (@wplus _ l%word r%word) : word_scope.
+  Notation "l ^* r" := (@wmult _ l%word r%word) : word_scope.
+  Notation "l ^- r" := (@wminus _ l%word r%word) : word_scope.
+  Notation "l ^/ r" := (@wdiv _ l%word r%word) : word_scope.
+  Notation "l ^% r" := (@wmod _ l%word r%word) : word_scope.
+End ArithmeticNotations.
 
 (** * Bitwise operators *)
 
@@ -274,8 +275,10 @@ Definition wor := bitwp orb.
 Definition wand := bitwp andb.
 Definition wxor := bitwp xorb.
 
-Notation "l ^| r" := (@wor _ l%word r%word) (at level 50, left associativity).
-Notation "l ^& r" := (@wand _ l%word r%word) (at level 40, left associativity).
+Module Import BitwiseNotations.
+  Notation "l ^| r" := (@wor _ l%word r%word) : word_scope.
+  Notation "l ^& r" := (@wand _ l%word r%word) : word_scope.
+End BitwiseNotations.
 
 (** * Conversion to and from [Z] *)
 
@@ -326,15 +329,17 @@ Definition wlt sz (l r : word sz) : Prop :=
 Definition wslt sz (l r : word sz) : Prop :=
   Z.lt (wordToZ l) (wordToZ r).
 
-Notation "w1 > w2" := (@wlt _ w2%word w1%word) : word_scope.
-Notation "w1 >= w2" := (~(@wlt _ w1%word w2%word)) : word_scope.
-Notation "w1 < w2" := (@wlt _ w1%word w2%word) : word_scope.
-Notation "w1 <= w2" := (~(@wlt _ w2%word w1%word)) : word_scope.
+Module Import ComparisonNotations.
+  Notation "w1 > w2" := (@wlt _ w2%word w1%word) : word_scope.
+  Notation "w1 >= w2" := (~(@wlt _ w1%word w2%word)) : word_scope.
+  Notation "w1 < w2" := (@wlt _ w1%word w2%word) : word_scope.
+  Notation "w1 <= w2" := (~(@wlt _ w2%word w1%word)) : word_scope.
 
-Notation "w1 '>s' w2" := (@wslt _ w2%word w1%word) (at level 70, w2 at next level) : word_scope.
-Notation "w1 '>s=' w2" := (~(@wslt _ w1%word w2%word)) (at level 70, w2 at next level) : word_scope.
-Notation "w1 '<s' w2" := (@wslt _ w1%word w2%word) (at level 70, w2 at next level) : word_scope.
-Notation "w1 '<s=' w2" := (~(@wslt _ w2%word w1%word)) (at level 70, w2 at next level) : word_scope.
+  Notation "w1 '>s' w2" := (@wslt _ w2%word w1%word) : word_scope.
+  Notation "w1 '>s=' w2" := (~(@wslt _ w1%word w2%word)) : word_scope.
+  Notation "w1 '<s' w2" := (@wslt _ w1%word w2%word) : word_scope.
+  Notation "w1 '<s=' w2" := (~(@wslt _ w2%word w1%word)) : word_scope.
+End ComparisonNotations.
 
 Definition wlt_dec : forall sz (l r : word sz), {l < r} + {l >= r}.
   refine (fun sz l r =>
@@ -358,8 +363,10 @@ Definition wltb{sz: nat}(l r: word sz): bool := BinNat.N.ltb (wordToN l) (wordTo
 
 Definition wsltb{sz: nat}(l r: word sz): bool := Z.ltb (wordToZ l) (wordToZ r).
 
-Notation "$ n" := (natToWord _ n) (at level 0).
-Notation "# n" := (wordToNat n) (at level 0).
+Module Import ConversionNotations.
+  Notation "$ n" := (natToWord _ n) : word_scope.
+  Notation "# n" := (wordToNat n).
+End ConversionNotations.
 
 (** * Bit shifting *)
 
@@ -422,8 +429,10 @@ Fixpoint wpow2 sz: word (S sz) :=
   | S sz' => (wpow2 sz')~0
   end.
 
-Notation "l ^<< r" := (@wlshift _ _ l%word r%word) (at level 35).
-Notation "l ^>> r" := (@wrshift _ _ l%word r%word) (at level 35).
+Module Import ShiftNotations.
+  Notation "l ^<< r" := (@wlshift _ _ l%word r%word) : word_scope.
+  Notation "l ^>> r" := (@wrshift _ _ l%word r%word) : word_scope.
+End ShiftNotations.
 
 (** * Setting an individual bit *)
 
@@ -7294,3 +7303,11 @@ Qed.
 
 Local Close Scope nat.
 Close Scope word_scope.
+
+Module Notations.
+  Export ArithmeticNotations.
+  Export BitwiseNotations.
+  Export ComparisonNotations.
+  Export ConversionNotations.
+  Export ShiftNotations.
+End Notations.

--- a/theories/WordScope.v
+++ b/theories/WordScope.v
@@ -7,4 +7,5 @@
    instead of Word.v. *)
 
 Require Export bbv.Word.
+Export Word.Notations.
 Open Scope word_scope.


### PR DESCRIPTION
Also adjust the level of $n, see the discussion in #5.

We also move all of the level specifications to ReservedNotations.v.
This allows early detection of notation conflicts, as any file importing
bbv.ReservedNotations will observe all notation conflicts that can arise
from importing any file of bbv.

Closes #5