### PR TITLE
Prepare porting from omega to lia

### DIFF
--- a/theories/NatLib.v
+++ b/theories/NatLib.v
@@ -1,5 +1,5 @@
 Require Import Coq.Arith.Div2.
-Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.NArith.
 Require Import Coq.ZArith.ZArith.
 
@@ -378,17 +378,17 @@ Proof.
   induction sz; simpl; auto; omega.
 Qed.
 
+Section omega_compat.
+
+Ltac omega ::= lia.
+
 Theorem Npow2_nat : forall n, nat_of_N (Npow2 n) = pow2 n.
   induction n as [|n IHn]; simpl; intuition.
   rewrite <- IHn; clear IHn.
   case_eq (Npow2 n); intuition.
-  rewrite untimes2.
-  match goal with
-  | [ |- context[Npos ?p~0] ]
-    => replace (Npos p~0) with (N.double (Npos p)) by reflexivity
-  end.
-  apply nat_of_Ndouble.
 Qed.
+
+End omega_compat.
 
 Theorem pow2_N : forall n, Npow2 n = N.of_nat (pow2 n).
 Proof.

--- a/theories/Nomega.v
+++ b/theories/Nomega.v
@@ -1,6 +1,7 @@
-(* Make [omega] work for [N] *)
+(* Make [lia] work for [N] *)
 
-Require Import Coq.Arith.Arith Coq.omega.Omega Coq.NArith.NArith.
+Require Import Coq.Arith.Arith Coq.micromega.Lia Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 
 Local Open Scope N_scope.
 
@@ -21,12 +22,17 @@ Theorem Nneq_in : forall n m,
   congruence.
 Qed.
 
+Section omega_compat.
+
+Local Ltac omega ::= lia.
+
 Theorem Nneq_out : forall n m,
   n <> m
   -> nat_of_N n <> nat_of_N m.
   intuition.
-  match goal with H0 : _ |- _ => apply nat_of_N_eq in H0; tauto end.
 Qed.
+
+End omega_compat.
 
 Theorem Nlt_out : forall n m, n < m
   -> (nat_of_N n < nat_of_N m)%nat.

--- a/theories/Word.v
+++ b/theories/Word.v
@@ -1,6 +1,6 @@
 (** Fixed precision machine words *)
 
-Require Import Coq.Arith.Arith Coq.Arith.Div2 Coq.NArith.NArith Coq.Bool.Bool Coq.omega.Omega.
+Require Import Coq.Arith.Arith Coq.Arith.Div2 Coq.NArith.NArith Coq.Bool.Bool Coq.ZArith.ZArith.
 Require Import Coq.Logic.Eqdep_dec Coq.Logic.EqdepFacts.
 Require Import Coq.Program.Tactics Coq.Program.Equality.
 Require Import Coq.setoid_ring.Ring.

--- a/theories/ZLib.v
+++ b/theories/ZLib.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.BinInt.
-Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 
 Local Open Scope Z_scope.


### PR DESCRIPTION
This patch makes bbv compatible with https://github.com/coq/coq/pull/7878,
while staying compatible with Coq master.