### PR TITLE
Export String in {Bin,Hex}Notation

### DIFF
--- a/theories/BinNotation.v
+++ b/theories/BinNotation.v
@@ -3,7 +3,7 @@
    https://github.com/arthuraa/poleiro/blob/master/theories/ForceOption.v
    to produce N instead of nat *)
 
-Require Import Coq.Strings.String.
+Require Export Coq.Strings.String.
 Require Import Coq.Strings.Ascii.
 Require Import Coq.NArith.NArith.
 

--- a/theories/HexNotation.v
+++ b/theories/HexNotation.v
@@ -3,7 +3,7 @@
    https://github.com/arthuraa/poleiro/blob/master/theories/ForceOption.v
    to produce N instead of nat *)
 
-Require Import Coq.Strings.String.
+Require Export Coq.Strings.String.
 Require Import Coq.Strings.Ascii.
 Require Import Coq.NArith.NArith.
 


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where string notations no longer
follow , but instead follow .

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362