### PR TITLE
compatibility with Coq PR #11906

### DIFF
--- a/src/bbv/NatLib.v
+++ b/src/bbv/NatLib.v
@@ -67,7 +67,7 @@ Theorem div2_odd : forall n,
   -> n = S (2 * div2 n).
   induction n as [n] using strong; simpl; intuition.
 
-  destruct n as [|n]; simpl in *; intuition.
+  destruct n as [|n]; simpl in *.
     discriminate.
   destruct n as [|n]; simpl in *; intuition.
   do 2 f_equal.
@@ -80,7 +80,7 @@ Theorem div2_even : forall n,
   induction n as [n] using strong; simpl; intuition.
 
   destruct n as [|n]; simpl in *; intuition.
-  destruct n as [|n]; simpl in *; intuition.
+  destruct n as [|n]; simpl in *.
     discriminate.
   f_equal.
   replace (div2 n + S (div2 n + 0)) with (S (div2 n + (div2 n + 0))); auto.


### PR DESCRIPTION
Coq PR https://github.com/coq/coq/pull/11906 extends `lia` with support for boolean operators.
This has the consequence that `intuition` is able to perform some
boolean reasoning e.g. true = false -> 0 = 1.
The PR removes (redundant) calls to `intuition`.