### PR TITLE
Avoid unary round-trip for binary literals

### DIFF
--- a/src/bbv/HexNotationWord.v
+++ b/src/bbv/HexNotationWord.v
@@ -1,5 +1,6 @@
 Require Export bbv.HexNotation.
 Require Import bbv.WordScope.
+Require bbv.BinNotation.
 
 Notation "'Ox' a" := (NToWord _ (hex a)) (at level 50).
 
@@ -11,14 +12,17 @@ Proof. reflexivity. Qed.
 Goal Ox"41" = WO~1~0~0~0~0~0~1.
 Proof. reflexivity. Qed.
 
-Notation "sz ''b' a" := (natToWord sz (bin a)) (at level 50).
+Notation "sz ''b' a" := (NToWord sz (BinNotation.bin a)) (at level 50).
 
-Notation "''b' a" := (natToWord _ (bin a)) (at level 50).
+Notation "''b' a" := (NToWord _ (BinNotation.bin a)) (at level 50).
 
 Goal 'b"00001010" = WO~0~0~0~0~1~0~1~0.
 Proof. reflexivity. Qed.
 
 Goal 'b"1000001" = WO~1~0~0~0~0~0~1.
 Proof. reflexivity. Qed.
+
+Goal 'b"111110000000000000101" = WO~1~1~1~1~1~0~0~0~0~0~0~0~0~0~0~0~0~0~1~0~1.
+Proof. cbv. reflexivity. Qed.
 
 


### PR DESCRIPTION
Avoids resource exhaustion due to exponential blowup when processing some literals.  For example, in the new test it previously failed with a stack overflow at `cbv`.