### PR TITLE
Alternate adaptation w.r.t. coq/coq#16004

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,1 +1,2 @@
 -Q src/bbv bbv
+-arg -w -arg -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality

--- a/src/bbv/BinNotation.v
+++ b/src/bbv/BinNotation.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 
 (* Adapted from http://poleiro.info/posts/2013-04-03-parse-errors-as-type-errors.html,
    https://github.com/arthuraa/poleiro/blob/master/theories/ForceOption.v

--- a/src/bbv/BinNotationZ.v
+++ b/src/bbv/BinNotationZ.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Export bbv.BinNotation.
 Require Export bbv.ReservedNotations.
 Require Import Coq.ZArith.BinInt.

--- a/src/bbv/DepEq.v
+++ b/src/bbv/DepEq.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Import Coq.Arith.Peano_dec.
 Require Import Coq.Logic.Eqdep Coq.Logic.Eqdep_dec Coq.Program.Equality.
 

--- a/src/bbv/DepEqNat.v
+++ b/src/bbv/DepEqNat.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 
 (* This file defines nat_cast, an alternative to eq_rect which works only for type nat instead
    of any type A.

--- a/src/bbv/HexNotation.v
+++ b/src/bbv/HexNotation.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 
 (* Adapted from http://poleiro.info/posts/2013-04-03-parse-errors-as-type-errors.html,
    https://github.com/arthuraa/poleiro/blob/master/theories/ForceOption.v

--- a/src/bbv/HexNotationWord.v
+++ b/src/bbv/HexNotationWord.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Export bbv.HexNotation.
 Require Import bbv.WordScope.
 Require bbv.BinNotation.

--- a/src/bbv/HexNotationZ.v
+++ b/src/bbv/HexNotationZ.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Export bbv.HexNotation.
 Require Export bbv.ReservedNotations.
 Require Import Coq.ZArith.BinInt.

--- a/src/bbv/NLib.v
+++ b/src/bbv/NLib.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Import Coq.NArith.NArith.
 
 Local Open Scope N_scope.

--- a/src/bbv/N_Z_nat_conversions.v
+++ b/src/bbv/N_Z_nat_conversions.v
@@ -1,4 +1,6 @@
+Set Loose Hint Behavior "Strict".
 (* This should be in the Coq library *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Arith.Arith Coq.NArith.NArith Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 

--- a/src/bbv/NatLib.v
+++ b/src/bbv/NatLib.v
@@ -1,3 +1,8 @@
+Set Loose Hint Behavior "Strict".
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Arith.Arith.
+Import Coq.Arith.PeanoNat.Nat.
 Require Import Coq.Arith.Div2.
 Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.NArith.

--- a/src/bbv/Nomega.v
+++ b/src/bbv/Nomega.v
@@ -1,5 +1,7 @@
+Set Loose Hint Behavior "Strict".
 (* Make [lia] work for [N] *)
 
+Require Import Coq.Bool.Bool Coq.Classes.Morphisms.
 Require Import Coq.Arith.Arith Coq.micromega.Lia Coq.NArith.NArith.
 Require Import Coq.ZArith.ZArith.
 

--- a/src/bbv/ReservedNotations.v
+++ b/src/bbv/ReservedNotations.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Reserved Notation "'Ob' a" (at level 50).
 Reserved Notation "'Ox' a" (at level 50).
 Reserved Notation "sz ''h' a" (at level 50).

--- a/src/bbv/Word.v
+++ b/src/bbv/Word.v
@@ -1,5 +1,7 @@
+Set Loose Hint Behavior "Strict".
 (** Fixed precision machine words *)
 
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.Equivalence Coq.Arith.PeanoNat Coq.ZArith.BinInt (* for hints *).
 Require Import Coq.Arith.Arith Coq.Arith.Div2 Coq.NArith.NArith Coq.Bool.Bool Coq.ZArith.ZArith.
 Require Import Coq.Logic.Eqdep_dec Coq.Logic.EqdepFacts.
 Require Import Coq.Program.Tactics Coq.Program.Equality.
@@ -12,6 +14,7 @@ Require Export bbv.DepEq bbv.DepEqNat.
 Require Import bbv.ReservedNotations.
 
 Require Import Coq.micromega.Lia.
+Local Existing Instances N.le_preorder Nat.add_wd Nat.div_wd Nat.divide_reflexive Nat.le_preorder Nat.le_wd Nat.lt_wd Nat.mod_wd Nat.mul_wd Nat.sub_wd Z.le_wd Z.le_preorder Z.lt_strorder.
 
 Set Implicit Arguments.
 
@@ -152,7 +155,7 @@ Proof.
   intros a; apply (shatter_word a).
 Qed.
 
-Hint Resolve shatter_word_0 : core.
+Global Hint Resolve shatter_word_0 : core.
 
 Definition weq : forall sz (x y : word sz), {x = y} + {x <> y}.
   refine (fix weq sz (x : word sz) : forall y : word sz, {x = y} + {x <> y} :=
@@ -1921,7 +1924,7 @@ Proof.
 Qed.
 
 
-Hint Resolve word_neq lt_le eq_le sub_0_eq le_neq_lt : worder.
+Global Hint Resolve word_neq lt_le eq_le sub_0_eq le_neq_lt : worder.
 
 Ltac shatter_word x :=
   match type of x with
@@ -2248,7 +2251,7 @@ Proof.
   assumption.
 Qed.
 
-Hint Resolve lt_word_le_nat : core.
+Global Hint Resolve lt_word_le_nat : core.
 
 Lemma wordToNat_natToWord_idempotent' : forall sz n,
   (n < pow2 sz)%nat

--- a/src/bbv/WordScope.v
+++ b/src/bbv/WordScope.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 (* Word.v defines notations for words by first opening word_scope, and then closing it again,
    to prevent notation clashes.
    It does, however, bind word_scope to the type word, so whenever an expression of type word

--- a/src/bbv/ZHints.v
+++ b/src/bbv/ZHints.v
@@ -1,3 +1,4 @@
+Set Loose Hint Behavior "Strict".
 Require Import Coq.ZArith.ZArith.
 Require Import bbv.ZLib.
 

--- a/src/bbv/ZLib.v
+++ b/src/bbv/ZLib.v
@@ -1,4 +1,7 @@
+Set Loose Hint Behavior "Strict".
+Require Import Coq.Classes.Morphisms.
 Require Import Coq.ZArith.BinInt.
+Import Coq.ZArith.BinInt.Z. (* for hints *)
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 


### PR DESCRIPTION
We `Set Loose Hint Behavior "Strict"` to ensure that all modules that
declare hints are imported.  This is more strict than necessary for
compatibility with the eventual change of semantics from `Global` to
`Export`, but there's no way currently to just preemptively flip the
default behavior, alas.

Closes #40

@ppedrot @samuelgruetter does this look alright?  (It's a bit less clean than I would like because `-set` cannot handle `Loose Hint Behavior`)