### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -15,13 +15,6 @@ jobs:
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq"       , PPA: "ppa:jgross-h/coq-master-daily"             }
         - { COQ_VERSION: "8.15.0", COQ_PACKAGE: "coq-8.15.0", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
         - { COQ_VERSION: "8.14.1", COQ_PACKAGE: "coq-8.14.1", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
-        - { COQ_VERSION: "8.13.2", COQ_PACKAGE: "coq-8.13.2", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.11.2", COQ_PACKAGE: "coq-8.11.2", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.10.2", COQ_PACKAGE: "coq-8.10.2", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.9.1" , COQ_PACKAGE: "coq-8.9.1" , PPA: "ppa:jgross-h/many-coq-versions"            }
-        - { COQ_VERSION: "8.8.2" , COQ_PACKAGE: "coq-8.8.2" , PPA: "ppa:jgross-h/many-coq-versions"            }
-        - { COQ_VERSION: "8.7.2" , COQ_PACKAGE: "coq-8.7.2" , PPA: "ppa:jgross-h/many-coq-versions"            }
 
     env: ${{ matrix.env }}
 

--- a/src/bbv/N_Z_nat_conversions.v
+++ b/src/bbv/N_Z_nat_conversions.v
@@ -20,15 +20,13 @@ Module N2Nat.
     rewrite <-? N_to_Z_to_nat.
     rewrite N2Z.inj_mod by assumption.
     apply Nat2Z.inj.
-    rewrite Zdiv.mod_Zmod.
-    - rewrite? Z2Nat.id; try apply N2Z.is_nonneg.
-      + reflexivity.
-      + pose proof (Z.mod_pos_bound (Z.of_N a) (Z.of_N b)) as Q.
-        destruct Q as [Q _].
-        * destruct b; try contradiction. simpl. constructor.
-        * exact Q.
-    - destruct b; try contradiction. simpl.
-      pose proof (Pos2Nat.is_pos p) as Q. lia.
+    rewrite Nat2Z.inj_mod.
+    rewrite? Z2Nat.id; try apply N2Z.is_nonneg.
+    - reflexivity.
+    - pose proof (Z.mod_pos_bound (Z.of_N a) (Z.of_N b)) as Q.
+      destruct Q as [Q _].
+      + destruct b; try contradiction. simpl. constructor.
+      + exact Q.
   Qed.
 
 End N2Nat.

--- a/src/bbv/NatLib.v
+++ b/src/bbv/NatLib.v
@@ -534,11 +534,11 @@ Proof.
   - subst. rewrite mod_0_r in *. simpl in *. now subst.
   - assert (a - b = 0 \/ b < a) as D by lia. destruct D as [D | D].
     + rewrite D. apply Nat.mod_0_l. assumption.
-    + apply Nat2Z.inj. simpl.
-      rewrite Zdiv.mod_Zmod by assumption.
+    + apply Nat2Z.inj.
+      rewrite Nat2Z.inj_mod.
       rewrite Nat2Z.inj_sub by lia.
       rewrite Zdiv.Zminus_mod.
-      rewrite <-! Zdiv.mod_Zmod by assumption.
+      rewrite <-! Nat2Z.inj_mod.
       rewrite H. rewrite H0.
       apply Z.mod_0_l.
       lia.


### PR DESCRIPTION
Use `Nat2Z.inj_mod` instead of deprecated `Zdiv.mod_Zmod` (coq/coq#16920).