### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/bbv/BinNotationZ.v
+++ b/src/bbv/BinNotationZ.v
@@ -1,7 +1,7 @@
 Set Loose Hint Behavior "Strict".
 Require Export bbv.BinNotation.
 Require Export bbv.ReservedNotations.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 
 Notation "'Ob' a" := (Z.of_N (bin a)).
 

--- a/src/bbv/DepEq.v
+++ b/src/bbv/DepEq.v
@@ -1,6 +1,6 @@
 Set Loose Hint Behavior "Strict".
-Require Import Coq.Arith.Peano_dec.
-Require Import Coq.Logic.Eqdep Coq.Logic.Eqdep_dec Coq.Program.Equality.
+From Coq Require Import Peano_dec.
+From Coq Require Import Eqdep Eqdep_dec Equality.
 
 (** * Equalities on dependent types *)
 

--- a/src/bbv/HexNotationZ.v
+++ b/src/bbv/HexNotationZ.v
@@ -1,7 +1,7 @@
 Set Loose Hint Behavior "Strict".
 Require Export bbv.HexNotation.
 Require Export bbv.ReservedNotations.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 
 Notation "'Ox' a" := (Z.of_N (hex a)).
 

--- a/src/bbv/N_Z_nat_conversions.v
+++ b/src/bbv/N_Z_nat_conversions.v
@@ -1,8 +1,8 @@
 Set Loose Hint Behavior "Strict".
 (* This should be in the Coq library *)
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.Arith.Arith Coq.NArith.NArith Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+From Coq Require Import Arith NArith ZArith.
+From Coq Require Import Lia.
 
 Lemma N_to_Z_to_nat: forall (a: N), Z.to_nat (Z.of_N a) = N.to_nat a.
 Proof.

--- a/src/bbv/NatLib.v
+++ b/src/bbv/NatLib.v
@@ -1,11 +1,11 @@
 Set Loose Hint Behavior "Strict".
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Bool.Bool.
-Require Import Coq.Arith.Arith.
-Import Coq.Arith.PeanoNat.Nat.
-Require Import Coq.micromega.Lia.
-Require Import Coq.NArith.NArith.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import Arith.
+Import PeanoNat.Nat.
+From Coq Require Import Lia.
+From Coq Require Import NArith.
+From Coq Require Import ZArith.
 Require Import bbv.N_Z_nat_conversions.
 Require Export bbv.Nomega.
 

--- a/src/bbv/Nomega.v
+++ b/src/bbv/Nomega.v
@@ -2,8 +2,8 @@ Set Loose Hint Behavior "Strict".
 (* Make [lia] work for [N] *)
 
 Require Import Coq.Bool.Bool Coq.Classes.Morphisms.
-Require Import Coq.Arith.Arith Coq.micromega.Lia Coq.NArith.NArith.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import Arith Lia NArith.
+From Coq Require Import ZArith.
 
 Local Open Scope N_scope.
 

--- a/src/bbv/Word.v
+++ b/src/bbv/Word.v
@@ -1,19 +1,19 @@
 Set Loose Hint Behavior "Strict".
 (** Fixed precision machine words *)
 
-Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.Equivalence Coq.Arith.PeanoNat Coq.ZArith.BinInt (* for hints *).
-Require Import Coq.Arith.Arith Coq.NArith.NArith Coq.Bool.Bool Coq.ZArith.ZArith.
-Require Import Coq.Logic.Eqdep_dec Coq.Logic.EqdepFacts.
-Require Import Coq.Program.Tactics Coq.Program.Equality.
-Require Import Coq.setoid_ring.Ring.
-Require Import Coq.setoid_ring.Ring_polynom.
+From Coq Require Import Morphisms Morphisms_Prop Equivalence PeanoNat BinInt (* for hints *).
+From Coq Require Import Arith NArith Bool ZArith.
+From Coq Require Import Eqdep_dec EqdepFacts.
+From Coq.Program Require Import Tactics Equality.
+From Coq Require Import Ring.
+From Coq Require Import Ring_polynom.
 Require Import bbv.Nomega.
 Require Export bbv.ZLib bbv.NatLib bbv.NLib.
 Require Export bbv.N_Z_nat_conversions.
 Require Export bbv.DepEq bbv.DepEqNat.
 Require Import bbv.ReservedNotations.
 
-Require Import Coq.micromega.Lia.
+From Coq Require Import Lia.
 Local Existing Instances N.le_preorder Nat.add_wd Nat.div_wd Nat.divide_reflexive Nat.le_preorder Nat.le_wd Nat.lt_wd Nat.mod_wd Nat.mul_wd Nat.sub_wd Z.le_wd Z.le_preorder Z.lt_strorder.
 
 Set Implicit Arguments.

--- a/src/bbv/ZHints.v
+++ b/src/bbv/ZHints.v
@@ -1,5 +1,5 @@
 Set Loose Hint Behavior "Strict".
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import bbv.ZLib.
 
 (* Properties of the lemmas in this list:

--- a/src/bbv/ZLib.v
+++ b/src/bbv/ZLib.v
@@ -1,9 +1,9 @@
 Set Loose Hint Behavior "Strict".
 Require Import Coq.Classes.Morphisms.
-Require Import Coq.ZArith.BinInt.
-Import Coq.ZArith.BinInt.Z. (* for hints *)
-Require Import Coq.micromega.Lia.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import BinInt.
+Import BinInt.Z. (* for hints *)
+From Coq Require Import Lia.
+From Coq Require Import ZArith.
 
 Local Open Scope Z_scope.
 


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.