### PR TITLE
Adapt to https://github.com/rocq-prover/rocq/pull/17876

### DIFF
--- a/src/bbv/ReservedNotations.v
+++ b/src/bbv/ReservedNotations.v
@@ -18,5 +18,3 @@ Reserved Notation "$ n" (at level 9, n at level 9, format "$ n").
 Reserved Notation "# n" (at level 0).
 Reserved Notation "l ^<< r" (at level 35).
 Reserved Notation "l ^>> r" (at level 35).
-Reserved Notation "w ~ 1" (at level 7, left associativity, format "w '~' '1'").
-Reserved Notation "w ~ 0" (at level 7, left associativity, format "w '~' '0'").


### PR DESCRIPTION
Adapt to https://github.com/rocq-prover/rocq/pull/17876

Don't rereserve notations already reserved in Corelib.