### PR TITLE
Add coq-bbv.opam file

### DIFF
--- a/coq-bbv.opam
+++ b/coq-bbv.opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "gmalecha@gmail.com"
+homepage: "https://github.com/mit-plv/bbv"
+dev-repo: "git+https://github.com/mit-plv/bbv.git"
+bug-reports: "https://github.com/mit-plv/bbv/issues"
+authors: ["Tej Chajed"
+          "Haogang Chen"
+          "Adam Chlipala"
+          "Joonwon Choi"
+          "Andres Erbsen"
+          "Jason Gross"
+          "Samuel Gruetter"
+          "Frans Kaashoek"
+          "Alex Konradi"
+          "Gregory Malecha"
+          "Duckki Oe"
+          "Murali Vijayaraghavan"
+          "Nickolai Zeldovich"
+          "Daniel Ziegler"
+]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.16" | = "dev"}
+]
+synopsis: "An implementation of bitvectors in Coq."


### PR DESCRIPTION
Based on the upstream opam-repo entry for coq-bbv.1.5, without the url section so it can be used for local development.