### PR TITLE
opam: declare conflict-class in the in-tree coq-bbv.opam

### DIFF
--- a/coq-bbv.opam
+++ b/coq-bbv.opam
@@ -29,4 +29,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.16" | = "dev"}
 ]
+conflict-class: [
+  "coq-bbv"
+]
 synopsis: "An implementation of bitvectors in Coq."


### PR DESCRIPTION
Same one-line fix as mit-plv/coqutil: the `coq-bbv` package file in the
`rocq-extra-dev` opam repository declares

```
conflict-class: [ "coq-bbv" ]
```

but the in-tree `coq-bbv.opam` does not. When bbv is `opam pin`ned to a git
URL, opam uses the in-tree file in place of the repository's one — wholesale,
not merged — so the declaration disappears and bbv can be co-installed with a
package that vendors it.

`conflict-class` is symmetric-by-membership, so a single side declaring it
protects nothing. The failure mode is a silent overwrite of shared
`user-contrib/` paths, surfacing much later as
`makes inconsistent assumptions over library ...` in an unrelated dependent.

This is latent for bbv today rather than actively broken — it bites on the
first pin — but it is the same defect and the same one-field fix. `opam lint`
reports no new warnings (the pre-existing synopsis-capitalisation warning is
untouched).


> *Authorship note: this was researched and written by an AI coding agent
> (Anthropic Claude), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*
